### PR TITLE
use 4 spaces instead of 2

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,9 @@
 def main(argv):
-  # このコードは引数と標準出力を用いたサンプルコードです。
-  # このコードは好きなように編集・削除してもらって構いません。
-  # ---
-  # This is a sample code to use arguments and outputs.
-  # Edit and remove this code as you like.
+    # このコードは引数と標準出力を用いたサンプルコードです。
+    # このコードは好きなように編集・削除してもらって構いません。
+    # ---
+    # This is a sample code to use arguments and outputs.
+    # Edit and remove this code as you like.
 
-  for i, v in enumerate(argv):
-    print("argv[{0}]: {1}".format(i, v))
+    for i, v in enumerate(argv):
+        print("argv[{0}]: {1}".format(i, v))


### PR DESCRIPTION
Python's default syntax rule is 4 white spaces and not 2.
Fix to standard rule