### PR TITLE
Update cli-template.yml

### DIFF
--- a/cli-template.yml
+++ b/cli-template.yml
@@ -1,5 +1,5 @@
 build:
-  - pip3 install -r requirements.txt
+  - pip3 install -q -r requirements.txt
 files:
   - requirements.txt
   - main.py


### PR DESCRIPTION
Supress warning for `pip3 install`

P.S. It is better to add same option to python2 template.

@TsubasaK111 